### PR TITLE
bug fix: node's mass should be 1+degree(node)

### DIFF
--- a/forceatlas2/forceatlas2.py
+++ b/forceatlas2/forceatlas2.py
@@ -96,7 +96,7 @@ def forceatlas2(
     nodes = []
     for i in range(0, G.shape[0]):
         n = fa2util.Node()
-        n.mass = 1 + numpy.sum(G[i])
+        n.mass = 1 + numpy.count_nonzero(G[i])
         n.old_dx = 0
         n.old_dy = 0
         n.dx = 0


### PR DESCRIPTION
Node's mass should be 1+degree(node) instead of 1+sum(edge_weights(node))
Reference: [ForceAtlas2](https://github.com/gephi/gephi/blob/master/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java)